### PR TITLE
Using default headers if user has not declared them.

### DIFF
--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -83,6 +83,11 @@ namespace websockets {
         WSString requestStr;
         WSString expectedAcceptKey;
     };
+
+    bool keywordDoesNotExist(std::vector<WSString>& usedKeys, WSSstring& keyWord) {
+        return std::find(usedKeys.begin(), usedKeys.end(), keyWord) == usedKeys.end();
+    }
+
     HandshakeRequestResult generateHandshake(const WSString& host, const WSString& uri, 
                                              const std::vector<std::pair<WSString, WSString>>& customHeaders) {
         
@@ -90,16 +95,29 @@ namespace websockets {
 
         WSString handshake = "GET " + uri + " HTTP/1.1\r\n";
         handshake += "Host: " + host + "\r\n";
-        handshake += "Upgrade: websocket\r\n";
-        handshake += "Connection: Upgrade\r\n";
         handshake += "Sec-WebSocket-Key: " + key + "\r\n";
-        handshake += "Sec-WebSocket-Version: 13\r\n";
-        handshake += "User-Agent: TinyWebsockets Client\r\n";
-        handshake += "Origin: https://github.com/gilmaimon/TinyWebsockets\r\n";
+
+        std::vector<WSString> usedKeys;
 
         for (const auto& header: customHeaders) {
             handshake += header.first + ": " + header.second + "\r\n";
+            usedKeys.push_back(header.first);
         }
+
+        if (keywordDoesNotExist(usedKeys, "Upgrade"))
+            handshake += "Upgrade: websocket\r\n";
+
+        if (keywordDoesNotExist(usedKeys, "Connection"))
+            handshake += "Connection: Upgrade\r\n";
+
+        if (keywordDoesNotExist(usedKeys, "Sec-WebSocket-Version"))
+            handshake += "Sec-WebSocket-Version: 13\r\n";
+
+        if (keywordDoesNotExist(usedKeys, "User-Agent"))
+            handshake += "User-Agent: TinyWebsockets Client\r\n";
+
+        if (keywordDoesNotExist(usedKeys, "Origin"))
+            handshake += "Origin: https://github.com/gilmaimon/TinyWebsockets\r\n";
 
         handshake += "\r\n";
 

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -104,20 +104,25 @@ namespace websockets {
             usedKeys.push_back(header.first);
         }
 
-        if (keywordDoesNotExist(usedKeys, "Upgrade"))
+        if (keywordDoesNotExist(usedKeys, "Upgrade")) {
             handshake += "Upgrade: websocket\r\n";
+        }
 
-        if (keywordDoesNotExist(usedKeys, "Connection"))
+        if (keywordDoesNotExist(usedKeys, "Connection")) {
             handshake += "Connection: Upgrade\r\n";
+        }
 
-        if (keywordDoesNotExist(usedKeys, "Sec-WebSocket-Version"))
+        if (keywordDoesNotExist(usedKeys, "Sec-WebSocket-Version")) {
             handshake += "Sec-WebSocket-Version: 13\r\n";
+        }
 
-        if (keywordDoesNotExist(usedKeys, "User-Agent"))
+        if (keywordDoesNotExist(usedKeys, "User-Agent")) {
             handshake += "User-Agent: TinyWebsockets Client\r\n";
+        }
 
-        if (keywordDoesNotExist(usedKeys, "Origin"))
+        if (keywordDoesNotExist(usedKeys, "Origin")) {
             handshake += "Origin: https://github.com/gilmaimon/TinyWebsockets\r\n";
+        }
 
         handshake += "\r\n";
 

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -88,6 +88,16 @@ namespace websockets {
         return std::find(usedKeys.begin(), usedKeys.end(), keyWord) == usedKeys.end();
     }
 
+    bool shouldAddDefaultHeader(const std::string& keyWord, const std::vector<std::pair<WSString, WSString>>& customHeaders) {
+        for (const auto& header : customHeaders) {
+            if(!keyWord.compare(header.first)) {
+                return false
+            }
+        }
+
+        return true;
+    }
+
     HandshakeRequestResult generateHandshake(const WSString& host, const WSString& uri, 
                                              const std::vector<std::pair<WSString, WSString>>& customHeaders) {
         

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -115,7 +115,7 @@ namespace websockets {
             handshake += "Upgrade: websocket\r\n";
         }
 
-        if (keywordDoesNotExist("Connection", customHeaders)) {
+        if (shouldAddDefaultHeader("Connection", customHeaders)) {
             handshake += "Connection: Upgrade\r\n";
         }
 

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -84,7 +84,7 @@ namespace websockets {
         WSString expectedAcceptKey;
     };
 
-    bool keywordDoesNotExist(std::vector<WSString>& usedKeys, std::string keyWord) {
+    bool keywordDoesNotExist(const std::vector<WSString>& usedKeys, const std::string& keyWord) {
         return std::find(usedKeys.begin(), usedKeys.end(), keyWord) == usedKeys.end();
     }
 

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -101,7 +101,10 @@ namespace websockets {
 
         for (const auto& header: customHeaders) {
             handshake += header.first + ": " + header.second + "\r\n";
-            usedKeys.push_back(header.first);
+
+            if (keywordDoesNotExist(usedKeys, header.first)) {
+                usedKeys.push_back(header.first);
+            }
         }
 
         if (keywordDoesNotExist(usedKeys, "Upgrade")) {

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -84,7 +84,7 @@ namespace websockets {
         WSString expectedAcceptKey;
     };
 
-    bool keywordDoesNotExist(std::vector<WSString>& usedKeys, WSSstring& keyWord) {
+    bool keywordDoesNotExist(std::vector<WSString>& usedKeys, std::string keyWord) {
         return std::find(usedKeys.begin(), usedKeys.end(), keyWord) == usedKeys.end();
     }
 

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -84,10 +84,6 @@ namespace websockets {
         WSString expectedAcceptKey;
     };
 
-    bool keywordDoesNotExist(const std::vector<WSString>& usedKeys, const std::string& keyWord) {
-        return std::find(usedKeys.begin(), usedKeys.end(), keyWord) == usedKeys.end();
-    }
-
     bool shouldAddDefaultHeader(const std::string& keyWord, const std::vector<std::pair<WSString, WSString>>& customHeaders) {
         for (const auto& header : customHeaders) {
             if(!keyWord.compare(header.first)) {

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -87,7 +87,7 @@ namespace websockets {
     bool shouldAddDefaultHeader(const std::string& keyWord, const std::vector<std::pair<WSString, WSString>>& customHeaders) {
         for (const auto& header : customHeaders) {
             if(!keyWord.compare(header.first)) {
-                return false
+                return false;
             }
         }
 

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -107,33 +107,27 @@ namespace websockets {
         handshake += "Host: " + host + "\r\n";
         handshake += "Sec-WebSocket-Key: " + key + "\r\n";
 
-        std::vector<WSString> usedKeys;
-
         for (const auto& header: customHeaders) {
             handshake += header.first + ": " + header.second + "\r\n";
-
-            if (keywordDoesNotExist(usedKeys, header.first)) {
-                usedKeys.push_back(header.first);
-            }
         }
 
-        if (keywordDoesNotExist(usedKeys, "Upgrade")) {
+        if (shouldAddDefaultHeader("Upgrade", customHeaders)) {
             handshake += "Upgrade: websocket\r\n";
         }
 
-        if (keywordDoesNotExist(usedKeys, "Connection")) {
+        if (keywordDoesNotExist("Connection", customHeaders)) {
             handshake += "Connection: Upgrade\r\n";
         }
 
-        if (keywordDoesNotExist(usedKeys, "Sec-WebSocket-Version")) {
+        if (shouldAddDefaultHeader("Sec-WebSocket-Version", customHeaders)) {
             handshake += "Sec-WebSocket-Version: 13\r\n";
         }
 
-        if (keywordDoesNotExist(usedKeys, "User-Agent")) {
+        if (shouldAddDefaultHeader("User-Agent", customHeaders)) {
             handshake += "User-Agent: TinyWebsockets Client\r\n";
         }
 
-        if (keywordDoesNotExist(usedKeys, "Origin")) {
+        if (shouldAddDefaultHeader("Origin", customHeaders)) {
             handshake += "Origin: https://github.com/gilmaimon/TinyWebsockets\r\n";
         }
 


### PR DESCRIPTION
Based on issue #69 (nice).

Pull request where the user can write headers before the connection. If the user does not write some required headers like `Origin` it will use the default hard-coded headers, if the user **does** write them they they are used rather than the hard-coded ones.

This is only implemented for the following headers:
* Upgrade
* Connection
* Sec-WebSocket-Version
* User-Agent
* Origin

Has been tested on an ESP8266. The server for websockets was an Elixir Phoenix one but it doesn't really matter what is the websocket server language.