### PR TITLE
SSL bug-fixing, implemented public-key certificate validation & EC Certificates for client-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ client.connect("wss://your-secured-server-ip:port/uri");
 The next sections describe board-specific code for using WSS with the library.
 
 ### ESP8266
-With the esp8266 there are 2 ways for using WSS. By default, `ArduinoWebsockets` does not validate the certificate chain. This can be set explicitly using:
+With the esp8266 there are multiple ways for using WSS. By default, `ArduinoWebsockets` does not validate the certificate chain. This can be set explicitly using:
 ```c++
 client.setInsecure();
 ```
@@ -204,6 +204,20 @@ const char ssl_fingerprint[] PROGMEM = "D5 07 4D 79 B2 D2 53 D7 74 E6 1B 46 C5 8
 
 client.setFingerprint(ssl_fingerprint);
 ```
+
+or you could use the `setKnownKey()` method to specify the public key of a certificate in order to validate the server you are connecting to.
+```
+PublicKey *publicKey = new PublicKey(public_key);
+client.setKnownKey(publicKey);
+```
+or you can specify the Certificate Authority (CA) using `setTrustAnchors` method, as follows:
+
+```
+X509List *serverTrustedCA = new X509List(ca_cert);
+client.setTrustAnchors(serverTrustedCA);
+```
+
+For client-side certificate validation, you can use RSA or EC certificates, using the method `setClientRSACert` or `setClientECCert` .
 
 ### ESP32
 With the esp32 you could either provide the full certificate, or provide no certificate. An example for setting CA Certificate:

--- a/examples/SecuredTwoWay-Esp8266-Client/SecuredTwoWay-Esp8266-Client.ino
+++ b/examples/SecuredTwoWay-Esp8266-Client/SecuredTwoWay-Esp8266-Client.ino
@@ -30,6 +30,11 @@ const char* password = "password"; //Enter Password
 
 const char* websockets_connection_string = "wss://echo.websocket.org/"; //Enter server adress
 
+/* NTP Time Servers */
+const char *ntp1 = "time.windows.com";
+const char *ntp2 = "pool.ntp.org";
+time_t now;
+
 // The hardcoded certificate authority for this example.
 // Don't use it on your own apps!!!!!
 const char ca_cert[] PROGMEM = R"EOF(
@@ -133,11 +138,25 @@ void setup() {
     // Connect to wifi
     WiFi.begin(ssid, password);
 
-    // Wait some time to connect to wifi
-    for(int i = 0; i < 10 && WiFi.status() != WL_CONNECTED; i++) {
-        Serial.print(".");
-        delay(1000);
+    Serial.println("Connecting to WiFi...");
+
+    // Wait until we are connected to WiFi
+    while(WiFi.status() != WL_CONNECTED) {
+      Serial.print(".");
+      delay(1000);
     }
+
+    Serial.println("Successfully connected to WiFi, setting time... ");
+
+    // We configure ESP8266's time, as we need it to validate the certificates
+    configTime(2 * 3600, 1, ntp1, ntp2);
+    while(now < 2 * 3600) {
+        Serial.print(".");
+        delay(500);
+        now = time(nullptr);
+    }
+    Serial.println("");
+    Serial.println("Time set, connecting to server...");
 
     // run callback when messages are received
     client.onMessage(onMessageCallback);

--- a/src/tiny_websockets/client.hpp
+++ b/src/tiny_websockets/client.hpp
@@ -80,7 +80,9 @@ namespace websockets {
   #ifdef ESP8266
     void setFingerprint(const char* fingerprint);
     void setClientRSACert(const X509List *cert, const PrivateKey *sk);
+	void setClientECCert(const X509List *cert, const PrivateKey *sk);
     void setTrustAnchors(const X509List *ta);
+	void setKnownKey(const PublicKey *pk);
   #elif defined(ESP32)
     void setCACert(const char* ca_cert);
     void setCertificate(const char* client_ca);
@@ -105,8 +107,11 @@ namespace websockets {
   #ifdef ESP8266
     const char* _optional_ssl_fingerprint = nullptr;
     const X509List* _optional_ssl_trust_anchors = nullptr;
-    const X509List* _optional_ssl_cert = nullptr;
-    const PrivateKey* _optional_ssl_private_key = nullptr;
+	const PublicKey* _optional_ssl_known_key = nullptr;
+    const X509List* _optional_ssl_rsa_cert = nullptr;
+    const PrivateKey* _optional_ssl_rsa_private_key = nullptr;
+	const X509List* _optional_ssl_ec_cert = nullptr;
+    const PrivateKey* _optional_ssl_ec_private_key = nullptr;
   #elif defined(ESP32)
     const char* _optional_ssl_ca_cert = nullptr;
     const char* _optional_ssl_client_ca = nullptr;

--- a/src/tiny_websockets/network/esp8266/esp8266_tcp.hpp
+++ b/src/tiny_websockets/network/esp8266/esp8266_tcp.hpp
@@ -21,15 +21,22 @@ namespace websockets { namespace network {
     void setFingerprint(const char* fingerprint) {
       this->client.setFingerprint(fingerprint);
     }
-    
-    void setClientRSACert(const X509List *cert, const PrivateKey *sk) {
-      this->client.setClientRSACert(cert, sk);
+
+	void setKnownKey(const PublicKey *pk) {
+		this->client.setKnownKey(pk);
 	}
-	
+
     void setTrustAnchors(const X509List *ta){
       this->client.setTrustAnchors(ta);
 	}
-        
+
+    void setClientRSACert(const X509List *cert, const PrivateKey *sk) {
+      this->client.setClientRSACert(cert, sk);
+	}
+
+	void setClientECCert(const X509List *cert, const PrivateKey *sk) {
+      this->client.setClientECCert(cert, sk, 0xFFFF, 0);
+	}
   };
 
   #define DUMMY_PORT 0

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -200,11 +200,11 @@ namespace websockets {
             if(this->_optional_ssl_fingerprint) {
                 client->setFingerprint(this->_optional_ssl_fingerprint);
             }
-            if(this->_optional_ssl_cert && this->_optional_ssl_private_key) {
-                client->setClientRSACert(this->_optional_ssl_cert, this->_optional_ssl_private_key);
-            }
             if(this->_optional_ssl_trust_anchors) {
                 client->setTrustAnchors(this->_optional_ssl_trust_anchors);
+            }
+            if(this->_optional_ssl_cert && this->_optional_ssl_private_key) {
+                client->setClientRSACert(this->_optional_ssl_cert, this->_optional_ssl_private_key);
             }
         }
         else {


### PR DESCRIPTION
Hi @gilmaimon ,

In this pull request I addressed issue #84 and also implemented server public-key certificate validation (using `setKnownKey` method) and EC certificate validation for client-side authentication using `setClientECCert` method, all for ESP8266, inherited from the official BearSSL library.

Also, I've corrected the [SecuredTwoWay-Example](https://github.com/adelin-mcbsoft/ArduinoWebsockets/blob/master/examples/SecuredTwoWay-Esp8266-Client/SecuredTwoWay-Esp8266-Client.ino) for ESP8266 and updated `readme.md` accordingly .

Let me know if you need any more info regarding this PR,

All the best,
Adelin

PS: A lot of white-space is shown in the _diff_, not sure why.