### PR TITLE
Making upgradeToSecuredConnection() public

### DIFF
--- a/src/tiny_websockets/client.hpp
+++ b/src/tiny_websockets/client.hpp
@@ -36,6 +36,8 @@ namespace websockets {
 
     void addHeader(const WSInterfaceString key, const WSInterfaceString value);
 
+    void upgradeToSecuredConnection();
+
     bool connect(const WSInterfaceString url);
     bool connect(const WSInterfaceString host, const int port, const WSInterfaceString path);
     
@@ -121,7 +123,5 @@ namespace websockets {
     void _handlePing(WebsocketsMessage);
     void _handlePong(WebsocketsMessage);
     void _handleClose(WebsocketsMessage);
-
-    void upgradeToSecuredConnection();
   };
 }

--- a/src/tiny_websockets/client.hpp
+++ b/src/tiny_websockets/client.hpp
@@ -36,11 +36,10 @@ namespace websockets {
 
     void addHeader(const WSInterfaceString key, const WSInterfaceString value);
 
-    void upgradeToSecuredConnection();
-
     bool connect(const WSInterfaceString url);
     bool connect(const WSInterfaceString host, const int port, const WSInterfaceString path);
-    
+    bool connectSecure(const WSInterfaceString host, const int port, const WSInterfaceString path);
+      
     void onMessage(const MessageCallback callback);
     void onMessage(const PartialMessageCallback callback);
 
@@ -123,5 +122,7 @@ namespace websockets {
     void _handlePing(WebsocketsMessage);
     void _handlePong(WebsocketsMessage);
     void _handleClose(WebsocketsMessage);
+
+    void upgradeToSecuredConnection();
   };
 }

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -358,6 +358,12 @@ namespace websockets {
         return true;
     }
 
+    bool WebsocketsClient::connectSecure(WSInterfaceString host, int port, WSInterfaceString path) {
+        upgradeToSecuredConnection();
+        
+        return connect(host, port, path);
+    }
+
     void WebsocketsClient::onMessage(MessageCallback callback) {
         this->_messagesCallback = callback;
     }


### PR DESCRIPTION
In order to connect to a websocket via [`WebsocketsClient::connect(WSInterfaceString host, int port, WSInterfaceString path)`](https://github.com/gilmaimon/ArduinoWebsockets/blob/5d90e9b1e90a462d434e52297806f2758021e5b9/src/websockets_client.cpp#L310),  the method `upgradeToSecuredConnection()` has to be called before. More details can be found in issue https://github.com/gilmaimon/ArduinoWebsockets/issues/114