### PR TITLE
[Support ESP32 3.0.0] Adding WiFiClientSecure in esp32_tcp.hpp

### DIFF
--- a/src/tiny_websockets/network/esp32/esp32_tcp.hpp
+++ b/src/tiny_websockets/network/esp32/esp32_tcp.hpp
@@ -8,6 +8,7 @@
 #include <tiny_websockets/network/generic_esp/generic_esp_clients.hpp>
 
 #include <WiFi.h>
+#include <WiFiClientSecure.h>
 #include <HTTPClient.h>
 
 namespace websockets { namespace network {


### PR DESCRIPTION
In Arduino ESP32 3.0.0, WiFiClientSecure is no longer included in WiFi.h, so it needs to be included separately.