### PR TITLE
Fixes for arduino esp32 v3.0.0

### DIFF
--- a/src/tiny_websockets/network/esp32/esp32_tcp.hpp
+++ b/src/tiny_websockets/network/esp32/esp32_tcp.hpp
@@ -8,6 +8,7 @@
 #include <tiny_websockets/network/generic_esp/generic_esp_clients.hpp>
 
 #include <WiFi.h>
+#include <WiFiClientSecure.h>
 #include <HTTPClient.h>
 
 namespace websockets { namespace network {

--- a/src/websockets_client.cpp
+++ b/src/websockets_client.cpp
@@ -134,7 +134,7 @@ namespace websockets {
 #ifndef _WS_CONFIG_SKIP_HANDSHAKE_ACCEPT_VALIDATION
         result.expectedAcceptKey = crypto::websocketsHandshakeEncodeKey(key);
 #endif
-        return std::move(result);
+        return result;
     }
 
     bool isWhitespace(char ch) {

--- a/src/websockets_endpoint.cpp
+++ b/src/websockets_endpoint.cpp
@@ -383,23 +383,19 @@ namespace internals {
 #endif
         // send the header
         std::string message_data = getHeader(len, opcode, fin, mask);
+
         if (mask) {
-            message_data += std::string(maskingKey, 4);
-        
-            size_t data_start = message_data.size();
-            message_data += std::string(data, len);
-
-            if (mask && memcmp(maskingKey, __TINY_WS_INTERNAL_DEFAULT_MASK, 4) != 0) {
-                remaskData(message_data, maskingKey, data_start, len);
-            }
-
-            this->_client->send(reinterpret_cast<const uint8_t*>(message_data.c_str()), message_data.size());
-        } else {
-            // avoid to allocate memory while concatenating std:sting, we do not alter the data so less send it in two parts. 
-            this->_client->send(reinterpret_cast<const uint8_t*>(message_data.c_str()), message_data.size());
-            this->_client->send(reinterpret_cast<const uint8_t*>(data), len);
+          message_data += std::string(maskingKey, 4);
         }
 
+        size_t data_start = message_data.size();
+        message_data += std::string(data, len);
+
+        if (mask && memcmp(maskingKey, __TINY_WS_INTERNAL_DEFAULT_MASK, 4) != 0) {
+          remaskData(message_data, maskingKey, data_start, len);
+        }
+
+        this->_client->send(reinterpret_cast<const uint8_t*>(message_data.c_str()), message_data.size());
         return true; // TODO dont assume success
     }
 


### PR DESCRIPTION
Fixes issues and warnings that happen when compiled with Arduino_esp32 v3.0.0
- include WiFiClientSecure required for SecuredEsp32TcpClient template in esp32_tcp.hpp
- fix warnings: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]